### PR TITLE
Use hostname -i instead of --all-ip-addresses

### DIFF
--- a/src/serviceReadyNotify.js
+++ b/src/serviceReadyNotify.js
@@ -26,7 +26,7 @@ var ServiceReadyNotify = function (registerManager) {
 
 ServiceReadyNotify.prototype.__getIp = function (cb) {
 	console.log('ServiceReadyNotify.__getIp');
-	childProcess.exec('hostname --all-ip-addresses', function(err, stdOut, stdErr) {
+	childProcess.exec('hostname -i', function(err, stdOut, stdErr) {
 
 	    var arr = stdOut.split('\n');
 	    var ip = '';


### PR DESCRIPTION
Paramter -i is available in hostnames provided by both, busybox (alpine
linux) and fedora (GNU inetutils) and it produces the same output so we
do not have to change anything.
